### PR TITLE
`Customer` Jdbc 저장소 추가

### DIFF
--- a/src/main/java/com/programmers/voucher/domain/customer/domain/Customer.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/domain/Customer.java
@@ -1,5 +1,7 @@
 package com.programmers.voucher.domain.customer.domain;
 
+import com.programmers.voucher.domain.customer.dto.CustomerDto;
+
 import java.util.UUID;
 
 public class Customer {
@@ -11,7 +13,15 @@ public class Customer {
         this.name = name;
     }
 
+    public CustomerDto toDto() {
+        return new CustomerDto(customerId, name);
+    }
+
     public String fullInfoString() {
         return "customerId: " + customerId + ", name: " + name;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
     }
 }

--- a/src/main/java/com/programmers/voucher/domain/customer/dto/CustomerDto.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/dto/CustomerDto.java
@@ -1,0 +1,21 @@
+package com.programmers.voucher.domain.customer.dto;
+
+import java.util.UUID;
+
+public class CustomerDto {
+    private final UUID customerId;
+    private final String name;
+
+    public CustomerDto(UUID customerId, String name) {
+        this.customerId = customerId;
+        this.name = name;
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
@@ -90,6 +90,9 @@ public class CustomerJdbcRepository implements CustomerRepository {
 
     @Override
     public void deleteById(UUID customerId) {
-
+        String sql = "delete from customer where customer_id = :customerId";
+        MapSqlParameterSource param = new MapSqlParameterSource()
+                .addValue("customerId", customerId);
+        template.update(sql, param);
     }
 }

--- a/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Repository;
 
 import javax.sql.DataSource;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -72,7 +73,8 @@ public class CustomerJdbcRepository implements CustomerRepository {
 
     @Override
     public List<Customer> findAll() {
-        return null;
+        String sql = "select * from customer";
+        return template.query(sql, Map.of(), customerRowMapper());
     }
 
     @Override

--- a/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
@@ -1,20 +1,73 @@
 package com.programmers.voucher.domain.customer.repository;
 
 import com.programmers.voucher.domain.customer.domain.Customer;
+import com.programmers.voucher.domain.customer.dto.CustomerDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
 
+import javax.sql.DataSource;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.programmers.voucher.global.util.DataErrorMessages.INCORRECT_UPDATED_RESULT_SIZE;
+
+@Repository
 public class CustomerJdbcRepository implements CustomerRepository {
+    private static final Logger LOG = LoggerFactory.getLogger(CustomerJdbcRepository.class);
+
+    private final NamedParameterJdbcTemplate template;
+
+    public CustomerJdbcRepository(DataSource dataSource) {
+        template = new NamedParameterJdbcTemplate(dataSource);
+    }
+
     @Override
     public void save(Customer customer) {
+        CustomerDto customerDto = customer.toDto();
 
+        String sql = "insert into customer(customer_id, name) values(:customerId, :name)";
+        MapSqlParameterSource param = new MapSqlParameterSource()
+                .addValue("customerId", customerDto.getCustomerId())
+                .addValue("name", customerDto.getName());
+
+        int saved = template.update(sql, param);
+        if (saved != 1) {
+            DataAccessException exception
+                    = new IncorrectResultSizeDataAccessException(INCORRECT_UPDATED_RESULT_SIZE, 1, saved);
+            LOG.error(exception.getMessage(), exception);
+            throw exception;
+        }
     }
 
     @Override
     public Optional<Customer> findById(UUID customerId) {
-        return Optional.empty();
+        String sql = "select * from customer where customer_id = :customerId";
+        MapSqlParameterSource param = new MapSqlParameterSource()
+                .addValue("customerId", customerId.toString());
+
+        try {
+            Customer customer = template.queryForObject(sql, param, customerRowMapper());
+            return Optional.ofNullable(customer);
+        } catch (EmptyResultDataAccessException ex) {
+            return Optional.empty();
+        }
+    }
+
+    private RowMapper<Customer> customerRowMapper() {
+        return (rs, rowNum) -> {
+            UUID customerId = UUID.fromString(rs.getString("customer_id"));
+            String name = rs.getString("name");
+
+            return new Customer(customerId, name);
+        };
     }
 
     @Override

--- a/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
@@ -1,0 +1,39 @@
+package com.programmers.voucher.domain.customer.repository;
+
+import com.programmers.voucher.domain.customer.domain.Customer;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class CustomerJdbcRepository implements CustomerRepository {
+    @Override
+    public void save(Customer customer) {
+
+    }
+
+    @Override
+    public Optional<Customer> findById(UUID customerId) {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<Customer> findAll() {
+        return null;
+    }
+
+    @Override
+    public void update(Customer customer) {
+
+    }
+
+    @Override
+    public void deleteAll() {
+
+    }
+
+    @Override
+    public void deleteById(UUID customerId) {
+
+    }
+}

--- a/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
@@ -84,7 +84,8 @@ public class CustomerJdbcRepository implements CustomerRepository {
 
     @Override
     public void deleteAll() {
-
+        String sql = "delete from customer";
+        template.update(sql, Map.of());
     }
 
     @Override

--- a/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerRepository.java
@@ -1,0 +1,21 @@
+package com.programmers.voucher.domain.customer.repository;
+
+import com.programmers.voucher.domain.customer.domain.Customer;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CustomerRepository {
+    void save(Customer customer);
+
+    Optional<Customer> findById(UUID customerId);
+
+    List<Customer> findAll();
+
+    void update(Customer customer);
+
+    void deleteAll();
+
+    void deleteById(UUID customerId);
+}

--- a/src/test/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepositoryTest.java
+++ b/src/test/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepositoryTest.java
@@ -81,7 +81,20 @@ class CustomerJdbcRepositoryTest {
     }
 
     @Test
+    @DisplayName("성공 - customer 전체 삭제")
     void deleteAll() {
+        //given
+        Customer customerA = new Customer(UUID.randomUUID(), "customerA");
+        Customer customerB = new Customer(UUID.randomUUID(), "customerB");
+        customerJdbcRepository.save(customerA);
+        customerJdbcRepository.save(customerB);
+
+        //when
+        customerJdbcRepository.deleteAll();
+
+        //then
+        List<Customer> findCustomers = customerJdbcRepository.findAll();
+        assertThat(findCustomers).isEmpty();
     }
 
     @Test

--- a/src/test/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepositoryTest.java
+++ b/src/test/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepositoryTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 
 import javax.sql.DataSource;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -59,7 +60,20 @@ class CustomerJdbcRepositoryTest {
     }
 
     @Test
+    @DisplayName("성공 - customer 목록 조회")
     void findAll() {
+        //given
+        Customer customerA = new Customer(UUID.randomUUID(), "customerA");
+        Customer customerB = new Customer(UUID.randomUUID(), "customerB");
+        customerJdbcRepository.save(customerA);
+        customerJdbcRepository.save(customerB);
+
+        //when
+        List<Customer> findCustomers = customerJdbcRepository.findAll();
+
+        //then
+        assertThat(findCustomers).usingRecursiveFieldByFieldElementComparator()
+                .contains(customerA, customerB);
     }
 
     @Test

--- a/src/test/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepositoryTest.java
+++ b/src/test/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepositoryTest.java
@@ -98,6 +98,17 @@ class CustomerJdbcRepositoryTest {
     }
 
     @Test
+    @DisplayName("성공 - customer 단건 삭제")
     void deleteById() {
+        //given
+        Customer customer = new Customer(UUID.randomUUID(), "customer");
+        customerJdbcRepository.save(customer);
+
+        //when
+        customerJdbcRepository.deleteById(customer.getCustomerId());
+
+        //then
+        Optional<Customer> optionalCustomer = customerJdbcRepository.findById(customer.getCustomerId());
+        assertThat(optionalCustomer).isEmpty();
     }
 }

--- a/src/test/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepositoryTest.java
+++ b/src/test/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepositoryTest.java
@@ -1,0 +1,76 @@
+package com.programmers.voucher.domain.customer.repository;
+
+import com.programmers.voucher.domain.customer.domain.Customer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import javax.sql.DataSource;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JdbcTest
+class CustomerJdbcRepositoryTest {
+
+    @Autowired
+    private CustomerJdbcRepository customerJdbcRepository;
+
+    @TestConfiguration
+    static class Config {
+        @Bean
+        public CustomerJdbcRepository customerJdbcRepository(DataSource dataSource) {
+            return new CustomerJdbcRepository(dataSource);
+        }
+    }
+
+    @Test
+    @DisplayName("성공 - customer 단건 저장")
+    void save() {
+        //given
+        Customer customer = new Customer(UUID.randomUUID(), "customer");
+
+        //when
+        customerJdbcRepository.save(customer);
+
+        //then
+        Customer findCustomer = customerJdbcRepository.findById(customer.getCustomerId()).get();
+        assertThat(findCustomer).usingRecursiveComparison().isEqualTo(customer);
+    }
+
+    @Test
+    @DisplayName("성공 - customer 단건 조회")
+    void findById() {
+        //given
+        Customer customer = new Customer(UUID.randomUUID(), "customer");
+        customerJdbcRepository.save(customer);
+
+        //when
+        Optional<Customer> optionalCustomer = customerJdbcRepository.findById(customer.getCustomerId());
+
+        //then
+        assertThat(optionalCustomer).isNotEmpty();
+        Customer findCustomer = optionalCustomer.get();
+        assertThat(findCustomer).usingRecursiveComparison().isEqualTo(customer);
+    }
+
+    @Test
+    void findAll() {
+    }
+
+    @Test
+    void update() {
+    }
+
+    @Test
+    void deleteAll() {
+    }
+
+    @Test
+    void deleteById() {
+    }
+}

--- a/src/test/resources/schema.sql
+++ b/src/test/resources/schema.sql
@@ -5,4 +5,8 @@ create table voucher (
     amount int not null
 );
 
-select * from voucher;
+drop table if exists customer;
+create table customer (
+    customer_id uuid primary key,
+    name varchar(20) not null
+)


### PR DESCRIPTION
## 작업 요약
`Customer` 도메인에 대한 Jdbc 저장소를 추가하였습니다.

## 작업 내용
- `CustomerRepository` 인터페이스를 추가하였습니다.
- `CustomerJdbcRepository`를 추가하였습니다. 다음의 기능을 추가했습니다.
  - 단건 저장
  - 단건 조회
  - 전체 조회
  - 단건 삭제
  - 전체 삭제 

## 추가 작업 필요
- `Customer` 도메인 객체의 요구사항 추가에 따라 단건 업데이트에 대한 작업이 추가로 필요합니다.