### PR TITLE
리팩토링 수행

### DIFF
--- a/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
@@ -12,7 +12,6 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-import javax.sql.DataSource;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -24,8 +23,8 @@ public class CustomerJdbcRepository implements CustomerRepository {
 
     private final NamedParameterJdbcTemplate template;
 
-    public CustomerJdbcRepository(DataSource dataSource) {
-        template = new NamedParameterJdbcTemplate(dataSource);
+    public CustomerJdbcRepository(NamedParameterJdbcTemplate template) {
+        this.template =template;
     }
 
     @Override

--- a/src/main/java/com/programmers/voucher/domain/customer/service/CustomerService.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/service/CustomerService.java
@@ -32,13 +32,12 @@ public class CustomerService {
 
     @Transactional
     public UUID createCustomer(String email, String name) {
-        boolean emailDuplication = customerRepository.findByEmail(email)
-                .isPresent();
-        if (emailDuplication) {
-            String errorMessage = MessageFormat.format(CustomerErrorMessages.DUPLICATE_EMAIL, email);
-            LOG.warn(errorMessage);
-            throw new DuplicateKeyException(errorMessage);
-        }
+        customerRepository.findByEmail(email)
+                .ifPresent(customer -> {
+                    String errorMessage = MessageFormat.format(CustomerErrorMessages.DUPLICATE_EMAIL, email);
+                    LOG.warn(errorMessage);
+                    throw new DuplicateKeyException(errorMessage);
+                });
 
         Customer customer = new Customer(UUID.randomUUID(), email, name);
         customerRepository.save(customer);

--- a/src/main/java/com/programmers/voucher/domain/voucher/domain/VoucherType.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/domain/VoucherType.java
@@ -7,9 +7,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.text.MessageFormat;
-import java.util.Arrays;
-import java.util.Objects;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.programmers.voucher.domain.voucher.util.VoucherErrorMessages.INVALID_VOUCHER_TYPE;
 
@@ -30,12 +34,14 @@ public enum VoucherType {
         this.voucherFactory = voucherFactory;
     }
 
-    public static VoucherType getValue(String voucherType) {
-        return Arrays.stream(values())
-                .filter(t -> Objects.equals(t.type, voucherType))
-                .findAny()
+    private static final Map<String, VoucherType> types =
+            Collections.unmodifiableMap(Stream.of(values())
+                    .collect(Collectors.toMap(VoucherType::getType, Function.identity())));
+
+    public static VoucherType getValue(String type) {
+        return Optional.ofNullable(types.get(type))
                 .orElseThrow(() -> {
-                    String errorMessage = MessageFormat.format(INVALID_VOUCHER_TYPE, voucherType);
+                    String errorMessage = MessageFormat.format(INVALID_VOUCHER_TYPE, type);
 
                     LOG.warn(errorMessage);
                     return new IllegalArgumentException(errorMessage);

--- a/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherJdbcRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherJdbcRepository.java
@@ -14,7 +14,6 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-import javax.sql.DataSource;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -27,8 +26,8 @@ public class VoucherJdbcRepository implements VoucherRepository {
 
     private final NamedParameterJdbcTemplate template;
 
-    public VoucherJdbcRepository(DataSource dataSource) {
-        this.template = new NamedParameterJdbcTemplate(dataSource);
+    public VoucherJdbcRepository(NamedParameterJdbcTemplate template) {
+        this.template = template;
     }
 
     @Override

--- a/src/main/java/com/programmers/voucher/global/io/command/ConsoleCommandType.java
+++ b/src/main/java/com/programmers/voucher/global/io/command/ConsoleCommandType.java
@@ -4,8 +4,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.text.MessageFormat;
-import java.util.Arrays;
-import java.util.Objects;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.programmers.voucher.global.util.ConsoleErrorMessages.INVALID_CONSOLE_COMMAND;
 
@@ -23,10 +27,12 @@ public enum ConsoleCommandType implements CommandType {
         this.type = type;
     }
 
+    private static final Map<String, ConsoleCommandType> types =
+            Collections.unmodifiableMap(Stream.of(values())
+                    .collect(Collectors.toMap(ConsoleCommandType::getType, Function.identity())));
+
     public static ConsoleCommandType getValue(String type) {
-        return Arrays.stream(values())
-                .filter(i -> Objects.equals(i.type, type))
-                .findAny()
+        return Optional.ofNullable(types.get(type))
                 .orElseThrow(() -> {
                     String errorMessage = MessageFormat.format(INVALID_CONSOLE_COMMAND, type);
 

--- a/src/main/java/com/programmers/voucher/global/io/command/CustomerCommandType.java
+++ b/src/main/java/com/programmers/voucher/global/io/command/CustomerCommandType.java
@@ -4,8 +4,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.text.MessageFormat;
-import java.util.Arrays;
-import java.util.Objects;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.programmers.voucher.global.util.ConsoleErrorMessages.INVALID_CUSTOMER_CONSOLE_COMMAND;
 
@@ -26,10 +28,12 @@ public enum CustomerCommandType implements CommandType {
         this.type = type;
     }
 
+    private static final Map<String, CustomerCommandType> types =
+            Collections.unmodifiableMap(Stream.of(values())
+                    .collect(Collectors.toMap(CustomerCommandType::getType, Function.identity())));
+
     public static CustomerCommandType getValue(String type) {
-        return Arrays.stream(values())
-                .filter(t -> Objects.equals(t.type, type))
-                .findAny()
+        return Optional.ofNullable(types.get(type))
                 .orElseThrow(() -> {
                     String errorMessage = MessageFormat.format(INVALID_CUSTOMER_CONSOLE_COMMAND, type);
 

--- a/src/main/java/com/programmers/voucher/global/io/command/VoucherCommandType.java
+++ b/src/main/java/com/programmers/voucher/global/io/command/VoucherCommandType.java
@@ -4,8 +4,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.text.MessageFormat;
-import java.util.Arrays;
-import java.util.Objects;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.programmers.voucher.global.util.ConsoleErrorMessages.INVALID_VOUCHER_CONSOLE_COMMAND;
 
@@ -24,10 +28,12 @@ public enum VoucherCommandType implements CommandType {
         this.type = type;
     }
 
+    private static final Map<String, VoucherCommandType> types =
+            Collections.unmodifiableMap(Stream.of(values())
+                    .collect(Collectors.toMap(VoucherCommandType::getType, Function.identity())));
+
     public static VoucherCommandType getValue(String type) {
-        return Arrays.stream(values())
-                .filter(t -> Objects.equals(t.type, type))
-                .findAny()
+        return Optional.ofNullable(types.get(type))
                 .orElseThrow(() -> {
                     String errorMessage = MessageFormat.format(INVALID_VOUCHER_CONSOLE_COMMAND, type);
 

--- a/src/test/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepositoryTest.java
+++ b/src/test/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepositoryTest.java
@@ -8,8 +8,8 @@ import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
-import javax.sql.DataSource;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -26,8 +26,8 @@ class CustomerJdbcRepositoryTest {
     @TestConfiguration
     static class Config {
         @Bean
-        public CustomerJdbcRepository customerJdbcRepository(DataSource dataSource) {
-            return new CustomerJdbcRepository(dataSource);
+        public CustomerJdbcRepository customerJdbcRepository(NamedParameterJdbcTemplate template) {
+            return new CustomerJdbcRepository(template);
         }
     }
 

--- a/src/test/java/com/programmers/voucher/domain/voucher/repository/VoucherJdbcRepositoryTest.java
+++ b/src/test/java/com/programmers/voucher/domain/voucher/repository/VoucherJdbcRepositoryTest.java
@@ -10,8 +10,8 @@ import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
-import javax.sql.DataSource;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -28,8 +28,8 @@ class VoucherJdbcRepositoryTest {
     @TestConfiguration
     static class Config {
         @Bean
-        public VoucherJdbcRepository voucherJdbcRepository(DataSource dataSource) {
-            return new VoucherJdbcRepository(dataSource);
+        public VoucherJdbcRepository voucherJdbcRepository(NamedParameterJdbcTemplate template) {
+            return new VoucherJdbcRepository(template);
         }
     }
 


### PR DESCRIPTION
## 작업 내용
- enum을 탐색하는 데 최적화를 수행했습니다.
- `JdbcRepository`가 `DataSource` 아니라 `NamedParameterJdbcTemplate`을 주입받도록 변경했습니다.
- `Optional` 검증을 좀 더 잘 활용하는 로직으로 변경했습니다.