### PR TITLE
리팩토링 수행

### DIFF
--- a/src/main/java/com/programmers/voucher/domain/customer/domain/Customer.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/domain/Customer.java
@@ -46,6 +46,7 @@ public class Customer {
     }
 
     public void update(String name, boolean banned) {
+        validateName(name);
         this.name = name;
         this.banned = banned;
     }

--- a/src/main/java/com/programmers/voucher/domain/customer/domain/Customer.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/domain/Customer.java
@@ -8,6 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import java.text.MessageFormat;
 import java.util.UUID;
+import java.util.regex.Matcher;
 
 public class Customer {
     private static final Logger LOG = LoggerFactory.getLogger(Customer.class);
@@ -26,7 +27,8 @@ public class Customer {
     }
 
     private void validateEmail(String email) {
-        if(!email.matches(CustomerFieldRegex.emailRegex)) {
+        Matcher emailMatcher = CustomerFieldRegex.EMAIL_PATTERN.matcher(email);
+        if(!emailMatcher.matches()) {
             String errorMessage = MessageFormat.format(CustomerErrorMessages.INVALID_EMAIL, email);
             LOG.warn(errorMessage);
             throw new IllegalArgumentException(errorMessage);
@@ -34,7 +36,8 @@ public class Customer {
     }
 
     private void validateName(String name) {
-        if (!name.matches(CustomerFieldRegex.nameRegex)) {
+        Matcher nameMatcher = CustomerFieldRegex.NAME_PATTERN.matcher(name);
+        if (!nameMatcher.matches()) {
             String errorMessage = MessageFormat.format(CustomerErrorMessages.INVALID_NAME, name);
             LOG.warn(errorMessage);
             throw new IllegalArgumentException(errorMessage);

--- a/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.programmers.voucher.global.util.DataAccessConstants.UPDATE_ONE;
+
 @Repository
 public class CustomerJdbcRepository implements CustomerRepository {
     private static final Logger LOG = LoggerFactory.getLogger(CustomerJdbcRepository.class);
@@ -40,8 +42,8 @@ public class CustomerJdbcRepository implements CustomerRepository {
                 .addValue("banned", customerDto.isBanned());
 
         int saved = template.update(sql, param);
-        if (saved != 1) {
-            DataAccessException ex = new IncorrectResultSizeDataAccessException(1, saved);
+        if (saved != UPDATE_ONE) {
+            DataAccessException ex = new IncorrectResultSizeDataAccessException(UPDATE_ONE, saved);
             LOG.error(ex.getMessage(), ex);
             throw ex;
         }
@@ -98,8 +100,8 @@ public class CustomerJdbcRepository implements CustomerRepository {
                 .addValue("banned", customerDto.isBanned());
 
         int updated = template.update(sql, param);
-        if (updated != 1) {
-            DataAccessException exception = new IncorrectResultSizeDataAccessException(1, updated);
+        if (updated != UPDATE_ONE) {
+            DataAccessException exception = new IncorrectResultSizeDataAccessException(UPDATE_ONE, updated);
             LOG.error(exception.getMessage(), exception);
             throw exception;
         }
@@ -117,8 +119,8 @@ public class CustomerJdbcRepository implements CustomerRepository {
         MapSqlParameterSource param = new MapSqlParameterSource()
                 .addValue("customerId", customerId);
         int deleted = template.update(sql, param);
-        if (deleted != 1) {
-            DataAccessException exception = new IncorrectResultSizeDataAccessException(1, deleted);
+        if (deleted != UPDATE_ONE) {
+            DataAccessException exception = new IncorrectResultSizeDataAccessException(UPDATE_ONE, deleted);
             LOG.error(exception.getMessage(), exception);
             throw exception;
         }

--- a/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
@@ -108,12 +108,6 @@ public class CustomerJdbcRepository implements CustomerRepository {
     }
 
     @Override
-    public void deleteAll() {
-        String sql = "delete from customer";
-        template.update(sql, Map.of());
-    }
-
-    @Override
     public void deleteById(UUID customerId) {
         String sql = "delete from customer where customer_id = :customerId";
         MapSqlParameterSource param = new MapSqlParameterSource()

--- a/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerRepository.java
@@ -19,7 +19,5 @@ public interface CustomerRepository {
 
     void update(Customer customer);
 
-    void deleteAll();
-
     void deleteById(UUID customerId);
 }

--- a/src/main/java/com/programmers/voucher/domain/customer/util/CustomerFieldRegex.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/util/CustomerFieldRegex.java
@@ -1,8 +1,11 @@
 package com.programmers.voucher.domain.customer.util;
 
+import java.util.regex.Pattern;
+
 public final class CustomerFieldRegex {
-    public static final String nameRegex = "^[A-Za-z0-9]{1,20}";
-    public static final String emailRegex = "^[A-Za-z0-9._%+-]{1,20}@[A-Za-z0-9.-]{1,20}\\.[A-Za-z]{2,3}$";
+    public static final Pattern NAME_PATTERN = Pattern.compile("^[A-Za-z0-9]{1,20}");
+    public static final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9._%+-]{1,20}@[A-Za-z0-9.-]{1,20}\\.[A-Za-z]{2,3}$");
+
 
     private CustomerFieldRegex() {
         

--- a/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherFileRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherFileRepository.java
@@ -18,6 +18,7 @@ import java.text.MessageFormat;
 import java.util.*;
 
 import static com.programmers.voucher.global.util.CommonErrorMessages.CANNOT_ACCESS_FILE;
+import static com.programmers.voucher.global.util.DataAccessConstants.UPDATE_ONE;
 
 @Repository
 @Profile("dev")
@@ -102,7 +103,7 @@ public class VoucherFileRepository implements VoucherRepository {
         List<Voucher> vouchers = findAll();
         boolean removed = vouchers.removeIf(v -> Objects.equals(v.getVoucherId(), voucherId));
         if(removed) {
-            IncorrectResultSizeDataAccessException ex = new IncorrectResultSizeDataAccessException(1, 0);
+            IncorrectResultSizeDataAccessException ex = new IncorrectResultSizeDataAccessException(UPDATE_ONE, 0);
             LOG.error(ex.getMessage());
             throw ex;
         }

--- a/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherFileRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherFileRepository.java
@@ -85,20 +85,6 @@ public class VoucherFileRepository implements VoucherRepository {
     }
 
     @Override
-    public void deleteAll() {
-        try (
-                BufferedWriter bw = new BufferedWriter(new FileWriter(file))
-        ) {
-            bw.write("");
-        } catch (IOException e) {
-            String errorMessage = MessageFormat.format(CANNOT_ACCESS_FILE, file.getPath());
-
-            LOG.error(errorMessage, e);
-            throw new FileAccessException(errorMessage, e);
-        }
-    }
-
-    @Override
     public void deleteById(UUID voucherId) {
         List<Voucher> vouchers = findAll();
         boolean removed = vouchers.removeIf(v -> Objects.equals(v.getVoucherId(), voucherId));

--- a/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherJdbcRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherJdbcRepository.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
+import static com.programmers.voucher.global.util.DataAccessConstants.UPDATE_ONE;
+
 @Repository
 @Profile("db")
 public class VoucherJdbcRepository implements VoucherRepository {
@@ -42,8 +44,8 @@ public class VoucherJdbcRepository implements VoucherRepository {
 
         int saved = template.update(sql, param);
 
-        if (saved != 1) {
-            DataAccessException ex = new IncorrectResultSizeDataAccessException(1, saved);
+        if (saved != UPDATE_ONE) {
+            DataAccessException ex = new IncorrectResultSizeDataAccessException(UPDATE_ONE, saved);
             LOG.error(ex.getMessage(), ex);
             throw ex;
         }
@@ -81,8 +83,8 @@ public class VoucherJdbcRepository implements VoucherRepository {
         MapSqlParameterSource param = new MapSqlParameterSource()
                 .addValue("voucherId", voucherId.toString());
         int deleted = template.update(sql, param);
-        if (deleted != 1) {
-            DataAccessException exception = new IncorrectResultSizeDataAccessException(1, deleted);
+        if (deleted != UPDATE_ONE) {
+            DataAccessException exception = new IncorrectResultSizeDataAccessException(UPDATE_ONE, deleted);
             LOG.error(exception.getMessage(), exception);
             throw exception;
         }

--- a/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherJdbcRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherJdbcRepository.java
@@ -15,7 +15,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -69,12 +68,6 @@ public class VoucherJdbcRepository implements VoucherRepository {
         } catch (EmptyResultDataAccessException ex) {
             return Optional.empty();
         }
-    }
-
-    @Override
-    public void deleteAll() {
-        String sql = "delete from voucher";
-        template.update(sql, Map.of());
     }
 
     @Override

--- a/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherMemoryRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherMemoryRepository.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Repository;
 
 import java.util.*;
 
+import static com.programmers.voucher.global.util.DataAccessConstants.UPDATE_ONE;
+
 @Repository
 @Profile("default")
 public class VoucherMemoryRepository implements VoucherRepository {
@@ -43,7 +45,7 @@ public class VoucherMemoryRepository implements VoucherRepository {
     public void deleteById(UUID voucherId) {
         Voucher remove = store.remove(voucherId);
         if(remove == null) {
-            throw new IncorrectResultSizeDataAccessException(1, 0);
+            throw new IncorrectResultSizeDataAccessException(UPDATE_ONE, 0);
         }
     }
 }

--- a/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherMemoryRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherMemoryRepository.java
@@ -37,11 +37,6 @@ public class VoucherMemoryRepository implements VoucherRepository {
     }
 
     @Override
-    public void deleteAll() {
-        store.clear();
-    }
-
-    @Override
     public void deleteById(UUID voucherId) {
         Voucher remove = store.remove(voucherId);
         if(remove == null) {

--- a/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherRepository.java
@@ -13,7 +13,5 @@ public interface VoucherRepository {
 
     Optional<Voucher> findById(UUID voucherId);
 
-    void deleteAll();
-
     void deleteById(UUID voucherId);
 }

--- a/src/main/java/com/programmers/voucher/global/io/textio/TextIoInput.java
+++ b/src/main/java/com/programmers/voucher/global/io/textio/TextIoInput.java
@@ -17,6 +17,8 @@ import org.springframework.stereotype.Component;
 
 import java.text.MessageFormat;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.programmers.voucher.domain.customer.util.CustomerErrorMessages.INVALID_EMAIL;
 import static com.programmers.voucher.domain.customer.util.CustomerErrorMessages.INVALID_NAME;
@@ -120,22 +122,23 @@ public class TextIoInput implements ConsoleInput {
     public CustomerCreateRequest inputCustomerCreateInfo() {
         String email = textIO.newStringInputReader()
                 .withValueChecker((val, itemName) -> {
-                    return regexValidate(val, CustomerFieldRegex.emailRegex, INVALID_EMAIL);
+                    return regexValidate(val, CustomerFieldRegex.EMAIL_PATTERN, INVALID_EMAIL);
                 })
                 .read(ENTER_EMAIL);
 
         String name = textIO.newStringInputReader()
                 .withValueChecker(((val, itemName) -> {
-                    return regexValidate(val, CustomerFieldRegex.nameRegex, INVALID_NAME);
+                    return regexValidate(val, CustomerFieldRegex.NAME_PATTERN, INVALID_NAME);
                 }))
                 .read(ENTER_NAME);
 
         return new CustomerCreateRequest(email, name);
     }
 
-    private List<String> regexValidate(String val, String emailRegex, String invalidEmailRange) {
+    private List<String> regexValidate(String val, Pattern fieldPattern, String invalidEmailRange) {
         List<String> messages = new ArrayList<>();
-        if (!val.matches(emailRegex)) {
+        Matcher fieldMatcher = fieldPattern.matcher(val);
+        if (!fieldMatcher.matches()) {
             messages.add(invalidEmailRange);
         }
         return messages;

--- a/src/main/java/com/programmers/voucher/global/util/DataAccessConstants.java
+++ b/src/main/java/com/programmers/voucher/global/util/DataAccessConstants.java
@@ -1,0 +1,5 @@
+package com.programmers.voucher.global.util;
+
+public class DataAccessConstants {
+    public static final int UPDATE_ONE = 1;
+}

--- a/src/test/java/com/programmers/voucher/domain/customer/domain/CustomerTest.java
+++ b/src/test/java/com/programmers/voucher/domain/customer/domain/CustomerTest.java
@@ -103,4 +103,31 @@ class CustomerTest {
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Test
+    @DisplayName("예외: customer 수정 - 20자를 초과한 이름")
+    void updateCustomer_ButInvalidName_OutOfRange_Then_Exception() {
+        //given
+        Customer customer = new Customer(UUID.randomUUID(), "customer@gmail.com", "customer");
+
+        //when
+        //then
+        String name = "anUsernameUpTo20Chars";
+        assertThatThrownBy(() -> customer.update(name, false))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "한글", "customer++", "customer.!"
+    })
+    @DisplayName("예외: customer 수정 - 잘못된 형식의 이름")
+    void updateCustomer_ButInvalidName_InvalidCharacter_Then_Exception(String name) {
+        //given
+        Customer customer = new Customer(UUID.randomUUID(), "customer@gmail.com", "customer");
+
+        //when
+        //then
+        assertThatThrownBy(() -> customer.update(name, false))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/src/test/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepositoryTest.java
+++ b/src/test/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepositoryTest.java
@@ -185,23 +185,6 @@ class CustomerJdbcRepositoryTest {
     }
 
     @Test
-    @DisplayName("성공: customer 전체 삭제")
-    void deleteAll() {
-        //given
-        Customer customerA = new Customer(UUID.randomUUID(), "customerA@gmail.com", "customerA");
-        Customer customerB = new Customer(UUID.randomUUID(), "customerB@gmail.com", "customerB");
-        customerJdbcRepository.save(customerA);
-        customerJdbcRepository.save(customerB);
-
-        //when
-        customerJdbcRepository.deleteAll();
-
-        //then
-        List<Customer> findCustomers = customerJdbcRepository.findAll();
-        assertThat(findCustomers).isEmpty();
-    }
-
-    @Test
     @DisplayName("성공: customer 단건 삭제")
     void deleteById() {
         //given

--- a/src/test/java/com/programmers/voucher/domain/voucher/repository/VoucherJdbcRepositoryTest.java
+++ b/src/test/java/com/programmers/voucher/domain/voucher/repository/VoucherJdbcRepositoryTest.java
@@ -96,23 +96,6 @@ class VoucherJdbcRepositoryTest {
     }
 
     @Test
-    @DisplayName("성공: voucher 전체 삭제")
-    void deleteAll() {
-        //given
-        FixedAmountVoucher fixedVoucher = new FixedAmountVoucher(UUID.randomUUID(), 10);
-        PercentDiscountVoucher percentVoucher = new PercentDiscountVoucher(UUID.randomUUID(), 10);
-        voucherJdbcRepository.save(fixedVoucher);
-        voucherJdbcRepository.save(percentVoucher);
-
-        //when
-        voucherJdbcRepository.deleteAll();
-
-        //then
-        List<Voucher> findVouchers = voucherJdbcRepository.findAll();
-        assertThat(findVouchers).isEmpty();
-    }
-
-    @Test
     @DisplayName("성공: voucher 단건 삭제")
     void deleteById() {
         //given

--- a/src/test/java/com/programmers/voucher/domain/voucher/repository/VoucherMemoryRepositoryTest.java
+++ b/src/test/java/com/programmers/voucher/domain/voucher/repository/VoucherMemoryRepositoryTest.java
@@ -85,23 +85,6 @@ class VoucherMemoryRepositoryTest {
     }
 
     @Test
-    @DisplayName("성공: voucher 전체 삭제")
-    void deleteAll() {
-        //given
-        Voucher fixedVoucherA = createFixedVoucher(UUID.randomUUID(), 10);
-        Voucher fixedVoucherB = createFixedVoucher(UUID.randomUUID(), 10);
-        voucherRepository.save(fixedVoucherA);
-        voucherRepository.save(fixedVoucherB);
-
-        //when
-        voucherRepository.deleteAll();
-
-        //then
-        List<Voucher> findVouchers = voucherRepository.findAll();
-        assertThat(findVouchers).isEmpty();
-    }
-
-    @Test
     @DisplayName("성공: voucher 단건 삭제")
     void deleteById() {
         //given


### PR DESCRIPTION
## 작용 내용
- 리포지토리에서 위험한 메서드인 `deleteAll()`을 제거했습니다.
- 기존 `Customer` 생성 시에만 수행하던 검증을 수정시에도 수행하도록 수정하였습니다.
- `string.matches(regex)`시 발생하는 오버헤드를 줄이기 위해 정규표현식 문자열 상수 대신 `Pattern` 객체를 가지고 있도록 변경했습니다.
- 쿼리로 인한 업데이트 로우를 나타내는 매직 넘버를 리포지토리에서 분리해서 관리합니다.