### PR TITLE
도메인 객체가 DTO 변환 방법을 모르도록 변경

### DIFF
--- a/src/main/java/com/programmers/voucher/domain/customer/controller/CustomerController.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/controller/CustomerController.java
@@ -26,7 +26,7 @@ public class CustomerController {
     public void findBlacklistCustomers() {
         List<Customer> customers = customerService.findBlacklistCustomers();
         List<CustomerDto> customerDtos = customers.stream()
-                .map(Customer::toDto)
+                .map(CustomerDto::from)
                 .toList();
 
         console.printCustomers(customerDtos);
@@ -35,7 +35,7 @@ public class CustomerController {
     public void findCustomers() {
         List<Customer> customers = customerService.findCustomers();
         List<CustomerDto> customerDtos = customers.stream()
-                .map(Customer::toDto)
+                .map(CustomerDto::from)
                 .toList();
 
         console.printCustomers(customerDtos);

--- a/src/main/java/com/programmers/voucher/domain/customer/domain/Customer.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/domain/Customer.java
@@ -1,6 +1,5 @@
 package com.programmers.voucher.domain.customer.domain;
 
-import com.programmers.voucher.domain.customer.dto.CustomerDto;
 import com.programmers.voucher.domain.customer.util.CustomerErrorMessages;
 import com.programmers.voucher.domain.customer.util.CustomerFieldRegex;
 import org.slf4j.Logger;
@@ -44,18 +43,10 @@ public class Customer {
         }
     }
 
-    public CustomerDto toDto() {
-        return new CustomerDto(customerId, email, name, banned);
-    }
-
     public void update(String name, boolean banned) {
         validateName(name);
         this.name = name;
         this.banned = banned;
-    }
-
-    public UUID getCustomerId() {
-        return customerId;
     }
 
     @Override
@@ -65,5 +56,21 @@ public class Customer {
                 ", email='" + email + '\'' +
                 ", name='" + name + '\'' +
                 '}';
+    }
+
+    public UUID getCustomerId() {
+        return customerId;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isBanned() {
+        return banned;
     }
 }

--- a/src/main/java/com/programmers/voucher/domain/customer/dto/CustomerDto.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/dto/CustomerDto.java
@@ -1,5 +1,7 @@
 package com.programmers.voucher.domain.customer.dto;
 
+import com.programmers.voucher.domain.customer.domain.Customer;
+
 import java.util.UUID;
 
 public class CustomerDto {
@@ -13,6 +15,15 @@ public class CustomerDto {
         this.email = email;
         this.name = name;
         this.banned = banned;
+    }
+
+    public static CustomerDto from(Customer customer) {
+        UUID customerId = customer.getCustomerId();
+        String email = customer.getEmail();
+        String name = customer.getName();
+        boolean banned = customer.isBanned();
+
+        return new CustomerDto(customerId, email, name, banned);
     }
 
     public UUID getCustomerId() {

--- a/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/repository/CustomerJdbcRepository.java
@@ -31,7 +31,7 @@ public class CustomerJdbcRepository implements CustomerRepository {
 
     @Override
     public void save(Customer customer) {
-        CustomerDto customerDto = customer.toDto();
+        CustomerDto customerDto = CustomerDto.from(customer);
 
         String sql = "insert into customer(customer_id, email, name, banned)" +
                 " values(:customerId, :email, :name, :banned)";
@@ -91,7 +91,7 @@ public class CustomerJdbcRepository implements CustomerRepository {
 
     @Override
     public void update(Customer customer) {
-        CustomerDto customerDto = customer.toDto();
+        CustomerDto customerDto = CustomerDto.from(customer);
 
         String sql = "update customer set name = :name, banned = :banned where customer_id = :customerId";
         MapSqlParameterSource param = new MapSqlParameterSource()

--- a/src/main/java/com/programmers/voucher/domain/voucher/controller/VoucherController.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/controller/VoucherController.java
@@ -36,7 +36,7 @@ public class VoucherController {
     public void findVouchers() {
         List<Voucher> vouchers = voucherService.findVouchers();
         List<VoucherDto> voucherDtos = vouchers.stream()
-                .map(Voucher::toDto)
+                .map(VoucherDto::from)
                 .toList();
 
         console.printVouchers(voucherDtos);

--- a/src/main/java/com/programmers/voucher/domain/voucher/domain/FixedAmountVoucher.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/domain/FixedAmountVoucher.java
@@ -1,6 +1,6 @@
 package com.programmers.voucher.domain.voucher.domain;
 
-import com.programmers.voucher.domain.voucher.dto.VoucherDto;
+import com.programmers.voucher.domain.voucher.pattern.VoucherVisitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,13 +35,13 @@ public class FixedAmountVoucher extends Voucher {
     }
 
     @Override
-    public VoucherDto toDto() {
-        return new VoucherDto(super.voucherId, VoucherType.FIXED_AMOUNT, amount);
+    public long totalAmount(long beforeAmount) {
+        return beforeAmount - amount;
     }
 
     @Override
-    public long totalAmount(long beforeAmount) {
-        return beforeAmount - amount;
+    public void accept(VoucherVisitor visitor) {
+        visitor.visit(this);
     }
 
     @Override
@@ -50,5 +50,9 @@ public class FixedAmountVoucher extends Voucher {
                 "voucherId=" + voucherId +
                 ", amount=" + amount +
                 '}';
+    }
+
+    public long getAmount() {
+        return amount;
     }
 }

--- a/src/main/java/com/programmers/voucher/domain/voucher/domain/PercentDiscountVoucher.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/domain/PercentDiscountVoucher.java
@@ -1,6 +1,6 @@
 package com.programmers.voucher.domain.voucher.domain;
 
-import com.programmers.voucher.domain.voucher.dto.VoucherDto;
+import com.programmers.voucher.domain.voucher.pattern.VoucherVisitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,13 +41,8 @@ public class PercentDiscountVoucher extends Voucher {
     }
 
     @Override
-    public VoucherDto toDto() {
-        return new VoucherDto(super.voucherId, VoucherType.PERCENT, percent);
-    }
-
-    @Override
-    public UUID getVoucherId() {
-        return voucherId;
+    public void accept(VoucherVisitor visitor) {
+        visitor.visit(this);
     }
 
     @Override
@@ -56,5 +51,9 @@ public class PercentDiscountVoucher extends Voucher {
                 "voucherId=" + voucherId +
                 ", percent=" + percent +
                 '}';
+    }
+
+    public long getPercent() {
+        return percent;
     }
 }

--- a/src/main/java/com/programmers/voucher/domain/voucher/domain/Voucher.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/domain/Voucher.java
@@ -1,6 +1,6 @@
 package com.programmers.voucher.domain.voucher.domain;
 
-import com.programmers.voucher.domain.voucher.dto.VoucherDto;
+import com.programmers.voucher.domain.voucher.pattern.VoucherVisitor;
 
 import java.util.UUID;
 
@@ -11,7 +11,7 @@ public abstract class Voucher {
         this.voucherId = voucherId;
     }
 
-    public abstract VoucherDto toDto();
+    public abstract void accept(VoucherVisitor visitor);
 
     public UUID getVoucherId() {
         return voucherId;

--- a/src/main/java/com/programmers/voucher/domain/voucher/dto/VoucherDto.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/dto/VoucherDto.java
@@ -1,5 +1,6 @@
 package com.programmers.voucher.domain.voucher.dto;
 
+import com.programmers.voucher.domain.voucher.domain.Voucher;
 import com.programmers.voucher.domain.voucher.domain.VoucherType;
 
 import java.util.UUID;
@@ -13,6 +14,11 @@ public class VoucherDto {
         this.voucherId = voucherId;
         this.voucherType = voucherType;
         this.amount = amount;
+    }
+
+    public static VoucherDto from(Voucher voucher) {
+        VoucherDtoConverter voucherDtoConverter = new VoucherDtoConverter();
+        return voucherDtoConverter.convert(voucher);
     }
 
     public UUID getVoucherId() {

--- a/src/main/java/com/programmers/voucher/domain/voucher/dto/VoucherDtoConverter.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/dto/VoucherDtoConverter.java
@@ -1,0 +1,33 @@
+package com.programmers.voucher.domain.voucher.dto;
+
+import com.programmers.voucher.domain.voucher.domain.FixedAmountVoucher;
+import com.programmers.voucher.domain.voucher.domain.PercentDiscountVoucher;
+import com.programmers.voucher.domain.voucher.domain.Voucher;
+import com.programmers.voucher.domain.voucher.domain.VoucherType;
+import com.programmers.voucher.domain.voucher.pattern.VoucherVisitor;
+
+public class VoucherDtoConverter implements VoucherVisitor {
+    private VoucherDto voucherDto;
+
+    public VoucherDto convert(Voucher voucher) {
+        voucher.accept(this);
+        return voucherDto;
+    }
+
+    @Override
+    public void visit(FixedAmountVoucher voucher) {
+        voucherDto = new VoucherDto(
+                voucher.getVoucherId(),
+                VoucherType.FIXED_AMOUNT,
+                voucher.getAmount());
+    }
+
+    @Override
+    public void visit(PercentDiscountVoucher voucher) {
+        voucherDto = new VoucherDto(
+                voucher.getVoucherId(),
+                VoucherType.PERCENT,
+                voucher.getPercent()
+        );
+    }
+}

--- a/src/main/java/com/programmers/voucher/domain/voucher/pattern/VoucherVisitor.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/pattern/VoucherVisitor.java
@@ -1,0 +1,9 @@
+package com.programmers.voucher.domain.voucher.pattern;
+
+import com.programmers.voucher.domain.voucher.domain.FixedAmountVoucher;
+import com.programmers.voucher.domain.voucher.domain.PercentDiscountVoucher;
+
+public interface VoucherVisitor {
+    void visit(FixedAmountVoucher voucher);
+    void visit(PercentDiscountVoucher voucher);
+}

--- a/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherFileRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherFileRepository.java
@@ -115,7 +115,7 @@ public class VoucherFileRepository implements VoucherRepository {
     }
 
     private String voucherToCsv(Voucher voucher) {
-        VoucherDto voucherDto = voucher.toDto();
+        VoucherDto voucherDto = VoucherDto.from(voucher);
         return voucherDto.getVoucherId()
                 + "," + voucherDto.getVoucherType()
                 + "," + voucherDto.getAmount();

--- a/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherJdbcRepository.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/repository/VoucherJdbcRepository.java
@@ -35,7 +35,7 @@ public class VoucherJdbcRepository implements VoucherRepository {
     public void save(Voucher voucher) {
         String sql = "insert into voucher(voucher_id, voucher_type, amount)" +
                 " values(:voucherId, :voucherType, :amount)";
-        VoucherDto voucherDto = voucher.toDto();
+        VoucherDto voucherDto = VoucherDto.from(voucher);
         MapSqlParameterSource param = new MapSqlParameterSource()
                 .addValue("voucherId", voucherDto.getVoucherId().toString())
                 .addValue("voucherType", voucherDto.getVoucherType().name())


### PR DESCRIPTION
## 작업 내용
- `Customer`, `Voucher` 도메인 객체 모델에서 DTO 변환 로직을 제거했습니다.
- `Voucher`는 `FixedAmountVoucher`, `PercentAmountVoucher`로부터 `VoucherDto` 생성을 위해 visitor 패턴을 이용하도록 했습니다.
  - `VoucherDtoConverter`가 해당 로직을 담당합니다.