### PR TITLE
`*ConsoleController`가 `Console`을 모르도록 변경

### DIFF
--- a/src/main/java/com/programmers/voucher/domain/customer/controller/CustomerConsoleController.java
+++ b/src/main/java/com/programmers/voucher/domain/customer/controller/CustomerConsoleController.java
@@ -4,55 +4,36 @@ import com.programmers.voucher.domain.customer.dto.CustomerDto;
 import com.programmers.voucher.domain.customer.dto.request.CustomerCreateRequest;
 import com.programmers.voucher.domain.customer.dto.request.CustomerUpdateRequest;
 import com.programmers.voucher.domain.customer.service.CustomerService;
-import com.programmers.voucher.global.io.Console;
-import com.programmers.voucher.global.util.ConsoleMessages;
 import org.springframework.stereotype.Controller;
 
-import java.text.MessageFormat;
 import java.util.List;
 import java.util.UUID;
 
 @Controller
 public class CustomerConsoleController {
-    private final Console console;
     private final CustomerService customerService;
 
-    public CustomerConsoleController(Console console, CustomerService customerService) {
-        this.console = console;
+    public CustomerConsoleController(CustomerService customerService) {
         this.customerService = customerService;
     }
 
-    public void findBlacklistCustomers() {
-        List<CustomerDto> customerDtos = customerService.findBlacklistCustomers();
-
-        console.printCustomers(customerDtos);
+    public List<CustomerDto> findBlacklistCustomers() {
+        return customerService.findBlacklistCustomers();
     }
 
-    public void findCustomers() {
-        List<CustomerDto> customerDtos = customerService.findCustomers();
-
-        console.printCustomers(customerDtos);
+    public List<CustomerDto> findCustomers() {
+        return customerService.findCustomers();
     }
 
-    public void createCustomer() {
-        CustomerCreateRequest request = console.inputCustomerCreateInfo();
-        UUID customerId = customerService.createCustomer(request.getEmail(), request.getName());
-
-        String consoleMessage = MessageFormat.format(ConsoleMessages.CREATED_NEW_CUSTOMER, customerId);
-        console.print(consoleMessage);
+    public UUID createCustomer(CustomerCreateRequest request) {
+        return customerService.createCustomer(request.getEmail(), request.getName());
     }
 
-    public void updateCustomer() {
-        CustomerUpdateRequest request = console.inputCustomerUpdateInfo();
+    public void updateCustomer(CustomerUpdateRequest request) {
         customerService.updateCustomer(request.getCustomerId(), request.getName(), request.isBanned());
-
-        console.print(ConsoleMessages.UPDATED_CUSTOMER);
     }
 
-    public void deleteCustomer() {
-        UUID customerId = console.inputUUID();
+    public void deleteCustomer(UUID customerId) {
         customerService.deleteCustomer(customerId);
-
-        console.print(ConsoleMessages.DELETED_CUSTOMER);
     }
 }

--- a/src/main/java/com/programmers/voucher/domain/voucher/controller/VoucherConsoleController.java
+++ b/src/main/java/com/programmers/voucher/domain/voucher/controller/VoucherConsoleController.java
@@ -6,12 +6,8 @@ import com.programmers.voucher.domain.voucher.service.VoucherService;
 import com.programmers.voucher.global.io.Console;
 import org.springframework.stereotype.Controller;
 
-import java.text.MessageFormat;
 import java.util.List;
 import java.util.UUID;
-
-import static com.programmers.voucher.global.util.ConsoleMessages.CREATED_NEW_VOUCHER;
-import static com.programmers.voucher.global.util.ConsoleMessages.DELETED_VOUCHER;
 
 @Controller
 public class VoucherConsoleController {
@@ -23,24 +19,15 @@ public class VoucherConsoleController {
         this.voucherService = voucherService;
     }
 
-    public void createVoucher() {
-        VoucherCreateRequest request = console.inputVoucherCreateInfo();
-        UUID voucherId = voucherService.createVoucher(request.getVoucherType(), request.getAmount());
-
-        String consoleMessage = MessageFormat.format(CREATED_NEW_VOUCHER, voucherId.toString());
-        console.print(consoleMessage);
+    public UUID createVoucher(VoucherCreateRequest request) {
+        return voucherService.createVoucher(request.getVoucherType(), request.getAmount());
     }
 
-    public void findVouchers() {
-        List<VoucherDto> voucherDtos = voucherService.findVouchers();
-
-        console.printVouchers(voucherDtos);
+    public List<VoucherDto> findVouchers() {
+        return voucherService.findVouchers();
     }
 
-    public void deleteVoucher() {
-        UUID voucherId = console.inputUUID();
+    public void deleteVoucher(UUID voucherId) {
         voucherService.deleteVoucher(voucherId);
-
-        console.print(DELETED_VOUCHER);
     }
 }

--- a/src/main/java/com/programmers/voucher/global/io/menu/ConsoleCustomerMenu.java
+++ b/src/main/java/com/programmers/voucher/global/io/menu/ConsoleCustomerMenu.java
@@ -1,9 +1,17 @@
 package com.programmers.voucher.global.io.menu;
 
 import com.programmers.voucher.domain.customer.controller.CustomerConsoleController;
+import com.programmers.voucher.domain.customer.dto.CustomerDto;
+import com.programmers.voucher.domain.customer.dto.request.CustomerCreateRequest;
+import com.programmers.voucher.domain.customer.dto.request.CustomerUpdateRequest;
 import com.programmers.voucher.global.io.Console;
 import com.programmers.voucher.global.io.command.CustomerCommandType;
+import com.programmers.voucher.global.util.ConsoleMessages;
 import org.springframework.stereotype.Component;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.UUID;
 
 @Component
 public class ConsoleCustomerMenu {
@@ -27,19 +35,28 @@ public class ConsoleCustomerMenu {
         CustomerCommandType customerCommandType = console.inputCustomerCommandType();
         switch (customerCommandType) {
             case CREATE -> {
-                customerController.createCustomer();
+                CustomerCreateRequest request = console.inputCustomerCreateInfo();
+                UUID customerId = customerController.createCustomer(request);
+                String consoleMessage = MessageFormat.format(ConsoleMessages.CREATED_NEW_CUSTOMER, customerId);
+                console.print(consoleMessage);
             }
             case LIST -> {
-                customerController.findCustomers();
+                List<CustomerDto> customers = customerController.findCustomers();
+                console.printCustomers(customers);
             }
             case UPDATE -> {
-                customerController.updateCustomer();
+                CustomerUpdateRequest request = console.inputCustomerUpdateInfo();
+                customerController.updateCustomer(request);
+                console.print(ConsoleMessages.UPDATED_CUSTOMER);
             }
             case DELETE -> {
-                customerController.deleteCustomer();
+                UUID customerId = console.inputUUID();
+                customerController.deleteCustomer(customerId);
+                console.print(ConsoleMessages.DELETED_CUSTOMER);
             }
             case BLACKLIST -> {
-                customerController.findBlacklistCustomers();
+                List<CustomerDto> blacklistCustomers = customerController.findBlacklistCustomers();
+                console.printCustomers(blacklistCustomers);
             }
             case HELP -> {
                 console.printCustomerCommandSet();

--- a/src/main/java/com/programmers/voucher/global/io/menu/ConsoleVoucherMenu.java
+++ b/src/main/java/com/programmers/voucher/global/io/menu/ConsoleVoucherMenu.java
@@ -1,9 +1,18 @@
 package com.programmers.voucher.global.io.menu;
 
 import com.programmers.voucher.domain.voucher.controller.VoucherConsoleController;
+import com.programmers.voucher.domain.voucher.dto.VoucherDto;
+import com.programmers.voucher.domain.voucher.dto.request.VoucherCreateRequest;
 import com.programmers.voucher.global.io.Console;
 import com.programmers.voucher.global.io.command.VoucherCommandType;
 import org.springframework.stereotype.Component;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.UUID;
+
+import static com.programmers.voucher.global.util.ConsoleMessages.CREATED_NEW_VOUCHER;
+import static com.programmers.voucher.global.util.ConsoleMessages.DELETED_VOUCHER;
 
 @Component
 public class ConsoleVoucherMenu {
@@ -27,13 +36,19 @@ public class ConsoleVoucherMenu {
         VoucherCommandType voucherCommandType = console.inputVoucherCommandType();
         switch (voucherCommandType) {
             case CREATE -> {
-                voucherController.createVoucher();
+                VoucherCreateRequest request = console.inputVoucherCreateInfo();
+                UUID voucherId = voucherController.createVoucher(request);
+                String consoleMessage = MessageFormat.format(CREATED_NEW_VOUCHER, voucherId.toString());
+                console.print(consoleMessage);
             }
             case LIST -> {
-                voucherController.findVouchers();
+                List<VoucherDto> vouchers = voucherController.findVouchers();
+                console.printVouchers(vouchers);
             }
             case DELETE -> {
-                voucherController.deleteVoucher();
+                UUID voucherId = console.inputUUID();
+                voucherController.deleteVoucher(voucherId);
+                console.print(DELETED_VOUCHER);
             }
             case HELP -> {
                 console.printVoucherCommandSet();

--- a/src/test/java/com/programmers/voucher/domain/customer/controller/CustomerConsoleControllerTest.java
+++ b/src/test/java/com/programmers/voucher/domain/customer/controller/CustomerConsoleControllerTest.java
@@ -4,7 +4,6 @@ import com.programmers.voucher.domain.customer.dto.CustomerDto;
 import com.programmers.voucher.domain.customer.dto.request.CustomerCreateRequest;
 import com.programmers.voucher.domain.customer.dto.request.CustomerUpdateRequest;
 import com.programmers.voucher.domain.customer.service.CustomerService;
-import com.programmers.voucher.global.io.Console;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,7 +15,9 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.programmers.voucher.testutil.CustomerTestUtil.createCustomerDto;
-import static org.mockito.ArgumentMatchers.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
@@ -25,9 +26,6 @@ class CustomerConsoleControllerTest {
 
     @InjectMocks
     private CustomerConsoleController customerController;
-
-    @Mock
-    private Console console;
 
     @Mock
     private CustomerService customerService;
@@ -39,14 +37,13 @@ class CustomerConsoleControllerTest {
         CustomerCreateRequest request = new CustomerCreateRequest("customer@gmail.com", "customer");
         UUID customerId = UUID.randomUUID();
 
-        given(console.inputCustomerCreateInfo()).willReturn(request);
         given(customerService.createCustomer(any(), any())).willReturn(customerId);
 
         //when
-        customerController.createCustomer();
+        customerController.createCustomer(request);
 
         //then
-        then(console).should().print(anyString());
+        then(customerService).should().createCustomer(any(), any());
     }
 
     @Test
@@ -54,28 +51,25 @@ class CustomerConsoleControllerTest {
     void updateCustomer() {
         //given
         CustomerUpdateRequest request = new CustomerUpdateRequest(UUID.randomUUID(), "updatedName", false);
-        given(console.inputCustomerUpdateInfo()).willReturn(request);
 
         //when
-        customerController.updateCustomer();
+        customerController.updateCustomer(request);
 
         //then
         then(customerService).should().updateCustomer(any(), any(), anyBoolean());
-        then(console).should().print(anyString());
     }
 
     @Test
     @DisplayName("성공: Customer 삭제 요청")
     void deleteCustomer() {
         //given
-        given(console.inputUUID()).willReturn(UUID.randomUUID());
+        UUID customerId = UUID.randomUUID();
 
         //when
-        customerController.deleteCustomer();
+        customerController.deleteCustomer(customerId);
 
         //then
         then(customerService).should().deleteCustomer(any());
-        then(console).should().print(anyString());
     }
 
     @Test
@@ -86,16 +80,16 @@ class CustomerConsoleControllerTest {
                 = createCustomerDto(UUID.randomUUID(), "customerA@gmail.com", "customerA", false);
         CustomerDto customerB
                 = createCustomerDto(UUID.randomUUID(), "customerB@gmail.com", "customerB", false);
-
         List<CustomerDto> customers = List.of(customerA, customerB);
 
         given(customerService.findCustomers()).willReturn(customers);
 
         //when
-        customerController.findCustomers();
+        List<CustomerDto> result = customerController.findCustomers();
 
         //then
-        then(console).should().printCustomers(anyList());
+        assertThat(result).usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(customerA, customerB);
     }
 
 }

--- a/src/test/java/com/programmers/voucher/domain/voucher/controller/VoucherConsoleControllerTest.java
+++ b/src/test/java/com/programmers/voucher/domain/voucher/controller/VoucherConsoleControllerTest.java
@@ -17,6 +17,7 @@ import java.util.UUID;
 
 import static com.programmers.voucher.testutil.VoucherTestUtil.createFixedVoucherDto;
 import static com.programmers.voucher.testutil.VoucherTestUtil.createPercentVoucherDto;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -40,15 +41,13 @@ class VoucherConsoleControllerTest {
         //given
         VoucherCreateRequest request = new VoucherCreateRequest(VoucherType.FIXED_AMOUNT, 10);
 
-        given(console.inputVoucherCreateInfo()).willReturn(request);
         given(voucherService.createVoucher(any(), anyLong())).willReturn(UUID.randomUUID());
 
         //when
-        voucherController.createVoucher();
+        voucherController.createVoucher(request);
 
         //then
         then(voucherService).should().createVoucher(any(), anyLong());
-        then(console).should().print(any());
 
     }
 
@@ -63,24 +62,23 @@ class VoucherConsoleControllerTest {
         given(voucherService.findVouchers()).willReturn(vouchers);
 
         //when
-        voucherController.findVouchers();
+        List<VoucherDto> result = voucherController.findVouchers();
 
         //then
-        then(voucherService).should().findVouchers();
-        then(console).should().printVouchers(any());
+        assertThat(result).usingRecursiveFieldByFieldElementComparator()
+                .containsExactlyInAnyOrder(fixedVoucher, percentVoucher);
     }
 
     @Test
     @DisplayName("성공: voucher 단건 삭제 요청")
     void deleteVoucher() {
         //given
-        given(console.inputUUID()).willReturn(UUID.randomUUID());
+        UUID voucherId = UUID.randomUUID();
 
         //when
-        voucherController.deleteVoucher();
+        voucherController.deleteVoucher(voucherId);
 
         //then
         then(voucherService).should().deleteVoucher(any());
-        then(console).should().print(any());
     }
 }

--- a/src/test/java/com/programmers/voucher/global/io/menu/ConsoleCustomerMenuTest.java
+++ b/src/test/java/com/programmers/voucher/global/io/menu/ConsoleCustomerMenuTest.java
@@ -10,6 +10,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
@@ -27,7 +28,7 @@ class ConsoleCustomerMenuTest {
     private CustomerConsoleController customerController;
 
     @Test
-    @DisplayName("성공: blacklist 명령 입력 - exit 명령 입력")
+    @DisplayName("성공: blacklist 명령 실행 - exit 명령 실행")
     void customerCommandTypeBlacklist() {
         //given
         given(console.inputCustomerCommandType())
@@ -37,12 +38,12 @@ class ConsoleCustomerMenuTest {
         consoleCustomerMenu.runningCustomerService();
 
         //then
-        then(console).should(times(2)).inputCustomerCommandType();
         then(customerController).should().findBlacklistCustomers();
+        then(console).should().printCustomers(any());
     }
 
     @Test
-    @DisplayName("성공: create 명령 입력 - exit 명령 입력")
+    @DisplayName("성공: create 명령 실행 - exit 명령 실행")
     void customerCommandTypeCreate() {
         //given
         given(console.inputCustomerCommandType())
@@ -52,12 +53,13 @@ class ConsoleCustomerMenuTest {
         consoleCustomerMenu.runningCustomerService();
 
         //then
-        then(console).should(times(2)).inputCustomerCommandType();
-        then(customerController).should().createCustomer();
+        then(console).should().inputCustomerCreateInfo();
+        then(customerController).should().createCustomer(any());
+        then(console).should().print(any());
     }
 
     @Test
-    @DisplayName("성공: list 명령 입력 - exit 명령 입력")
+    @DisplayName("성공: list 명령 실행 - exit 명령 실행")
     void customerCommandTypeList() {
         //given
         given(console.inputCustomerCommandType())
@@ -67,12 +69,12 @@ class ConsoleCustomerMenuTest {
         consoleCustomerMenu.runningCustomerService();
 
         //then
-        then(console).should(times(2)).inputCustomerCommandType();
         then(customerController).should().findCustomers();
+        then(console).should().printCustomers(any());
     }
 
     @Test
-    @DisplayName("성공: update 명령 입력 - exit 명령 입력")
+    @DisplayName("성공: update 명령 실행 - exit 명령 실행")
     void customerCommandTypeUpdate() {
         //given
         given(console.inputCustomerCommandType())
@@ -82,12 +84,13 @@ class ConsoleCustomerMenuTest {
         consoleCustomerMenu.runningCustomerService();
 
         //then
-        then(console).should(times(2)).inputCustomerCommandType();
-        then(customerController).should().updateCustomer();
+        then(console).should().inputCustomerUpdateInfo();
+        then(customerController).should().updateCustomer(any());
+        then(console).should().print(any());
     }
 
     @Test
-    @DisplayName("성공: delete 명령 입력 - exit 명령 입력")
+    @DisplayName("성공: delete 명령 실행 - exit 명령 실행")
     void customerCommandTypeDelete() {
         //given
         given(console.inputCustomerCommandType())
@@ -97,12 +100,13 @@ class ConsoleCustomerMenuTest {
         consoleCustomerMenu.runningCustomerService();
 
         //then
-        then(console).should(times(2)).inputCustomerCommandType();
-        then(customerController).should().deleteCustomer();
+        then(console).should().inputUUID();
+        then(customerController).should().deleteCustomer(any());
+        then(console).should().print(any());
     }
 
     @Test
-    @DisplayName("성공: help 명령 입력 - exit 명령 입력")
+    @DisplayName("성공: help 명령 실행 - exit 명령 실행")
     void customerCommandTypeHelp() {
         //given
         given(console.inputCustomerCommandType())
@@ -112,7 +116,6 @@ class ConsoleCustomerMenuTest {
         consoleCustomerMenu.runningCustomerService();
 
         //then
-        then(console).should(times(2)).inputCustomerCommandType();
         then(console).should(times(2)).printCustomerCommandSet();
     }
 }

--- a/src/test/java/com/programmers/voucher/global/io/menu/ConsoleVoucherMenuTest.java
+++ b/src/test/java/com/programmers/voucher/global/io/menu/ConsoleVoucherMenuTest.java
@@ -1,6 +1,7 @@
 package com.programmers.voucher.global.io.menu;
 
 import com.programmers.voucher.domain.voucher.controller.VoucherConsoleController;
+import com.programmers.voucher.domain.voucher.dto.VoucherDto;
 import com.programmers.voucher.global.io.Console;
 import com.programmers.voucher.global.io.command.VoucherCommandType;
 import org.junit.jupiter.api.DisplayName;
@@ -10,6 +11,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
+import java.util.UUID;
+
+import static com.programmers.voucher.testutil.VoucherTestUtil.createFixedVoucherDto;
+import static com.programmers.voucher.testutil.VoucherTestUtil.createPercentVoucherDto;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
@@ -27,37 +34,44 @@ class ConsoleVoucherMenuTest {
     private VoucherConsoleController voucherController;
 
     @Test
-    @DisplayName("성공: create 명령 입력 - exit 명령 입력")
+    @DisplayName("성공: create 명령 실행 - exit 명령 실행")
     public void voucherCommandTypeCreate() {
         //given
         given(console.inputVoucherCommandType())
                 .willReturn(VoucherCommandType.CREATE, VoucherCommandType.EXIT);
+        given(voucherController.createVoucher(any())).willReturn(UUID.randomUUID());
 
         //when
         consoleVoucherMenu.runningVoucherService();
 
         //then
-        then(console).should(times(2)).inputVoucherCommandType();
-        then(voucherController).should().createVoucher();
+        then(console).should().inputVoucherCreateInfo();
+        then(voucherController).should().createVoucher(any());
+        then(console).should().print(any());
     }
 
     @Test
-    @DisplayName("성공: list 명령 입력 - exit 명령 입력")
+    @DisplayName("성공: list 명령 실행 - exit 명령 실행")
     void voucherCommandTypeList() {
         //given
+        VoucherDto fixedVoucher = createFixedVoucherDto(UUID.randomUUID(), 10);
+        VoucherDto percentVoucher = createPercentVoucherDto(UUID.randomUUID(), 10);
+        List<VoucherDto> vouchers = List.of(fixedVoucher, percentVoucher);
+
         given(console.inputVoucherCommandType())
                 .willReturn(VoucherCommandType.LIST, VoucherCommandType.EXIT);
+        given(voucherController.findVouchers()).willReturn(vouchers);
 
         //when
         consoleVoucherMenu.runningVoucherService();
 
         //then
-        then(console).should(times(2)).inputVoucherCommandType();
         then(voucherController).should().findVouchers();
+        then(console).should().printVouchers(any());
     }
 
     @Test
-    @DisplayName("성공: voucher 명령 입력 - delete 명령 입력 - exit 명령 입력")
+    @DisplayName("성공: delete 명령 실행 - exit 명령 실행")
     void voucherCommandTypeDelete() {
         //given
         given(console.inputVoucherCommandType())
@@ -67,12 +81,13 @@ class ConsoleVoucherMenuTest {
         consoleVoucherMenu.runningVoucherService();
 
         //then
-        then(console).should(times(2)).inputVoucherCommandType();
-        then(voucherController).should().deleteVoucher();
+        then(console).should().inputUUID();
+        then(voucherController).should().deleteVoucher(any());
+        then(console).should().print(any());
     }
 
     @Test
-    @DisplayName("성공: help 명령 입력 - exit 명령 입력")
+    @DisplayName("성공: help 명령 실행 - exit 명령 실행")
     void voucherCommandTypeHelp() {
         //given
         given(console.inputVoucherCommandType())
@@ -82,7 +97,6 @@ class ConsoleVoucherMenuTest {
         consoleVoucherMenu.runningVoucherService();
 
         //then
-        then(console).should(times(2)).inputVoucherCommandType();
         then(console).should(times(2)).printVoucherCommandSet();
     }
 }


### PR DESCRIPTION
## 작업 내용
`Customer/Voucher`의 `*ConsoleController`가 `Console` 인터페이스를 모르도록 변경했습니다. 

- `*ConsoleController`는 파라미터로 입력받은 `DTO`로부터 Service에 값을 넘겨주고, Service로부터의 응답을 반환하도록 변경했습니다.
- `Console*Menu`는 각 Controller에 필요한 인수를 `Console`로 입력받고, Controller로부터의 응답을 `Console`로 출력합니다.